### PR TITLE
Cve 2019 13038

### DIFF
--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -116,6 +116,10 @@ int am_validate_redirect_url(request_rec *r, const char *url)
 
     /* Sanity check of the scheme of the domain. We only allow http and https. */
     if (uri.scheme) {
+        /* http and https schemes without hostname are invalid. */
+        if (!uri.hostname) {
+            return HTTP_BAD_REQUEST;
+        }
         if (strcasecmp(uri.scheme, "http")
             && strcasecmp(uri.scheme, "https")) {
             AM_LOG_RERROR(APLOG_MARK, APLOG_ERR, 0, r,

--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -118,6 +118,9 @@ int am_validate_redirect_url(request_rec *r, const char *url)
     if (uri.scheme) {
         /* http and https schemes without hostname are invalid. */
         if (!uri.hostname) {
+            AM_LOG_RERROR(APLOG_MARK, APLOG_ERR, 0, r,
+                          "Preventing redirect with scheme but no hostname: %s",
+                          url);
             return HTTP_BAD_REQUEST;
         }
         if (strcasecmp(uri.scheme, "http")


### PR DESCRIPTION
This PR resurrects https://github.com/Uninett/mod_auth_mellon/pull/220 and fixes CVE-2019-13038

There are also unit tests for `am_validate_redirect_url` added.

The last patch I'm not sure about. It is based on Olav's suggestion in https://github.com/Uninett/mod_auth_mellon/pull/220#pullrequestreview-292190490 and equally on the hardening that was done in mod_auth_openidc, but OTOH it is a change in behaviour and might bite some users. So I'd appreciate opinions.