### PR TITLE
Add "None" option for SameSite cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,11 @@ MellonDiagnosticsEnable Off
 
         # MellonCookieSameSite allows control over the SameSite value used
         # for the authentication cookie.
-        # The setting accepts values of "Strict" or "Lax"
-        # If not set, the SameSite attribute is not set on the cookie.
+        # The setting accepts values of "Strict", "Lax", or "None".
+        # When using none, you should set "MellonSecureCookie On" to prevent
+        # compatibility issues with newer browsers.
+        # If not set, the SameSite attribute is not set on the cookie. In newer
+        # browsers, this may cause SameSite to default to "Lax"
         # Default: not set
         # MellonCookieSameSite lax
 

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -164,7 +164,8 @@ typedef enum {
 typedef enum {
   am_samesite_default,
   am_samesite_lax,
-  am_samesite_strict
+  am_samesite_strict,
+  am_samesite_none,
 } am_samesite_t;
 
 typedef enum {

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -583,6 +583,8 @@ static const char *am_set_samesite_slot(cmd_parms *cmd,
         d->cookie_samesite = am_samesite_lax;
     } else if(!strcasecmp(arg, "strict")) {
         d->cookie_samesite = am_samesite_strict;
+    } else if(!strcasecmp(arg, "none")) {
+        d->cookie_samesite = am_samesite_none;
     } else {
         return "The MellonCookieSameSite parameter must be 'lax' or 'strict'";
     }

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -1,7 +1,7 @@
 /*
  *
  *   auth_mellon_cookie.c: an authentication apache module
- *   Copyright © 2003-2007 UNINETT (http://www.uninett.no/)
+ *   Copyright Â© 2003-2007 UNINETT (http://www.uninett.no/)
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -73,6 +73,8 @@ static const char *am_cookie_params(request_rec *r)
         cookie_samesite = "; SameSite=Lax";
     } else if (cfg->cookie_samesite == am_samesite_strict) {
         cookie_samesite = "; SameSite=Strict";
+    } else if (cfg->cookie_samesite == am_samesite_none) {
+        cookie_samesite = "; SameSite=None";
     }
 
     secure_cookie = cfg->secure;

--- a/auth_mellon_diagnostics.c
+++ b/auth_mellon_diagnostics.c
@@ -214,6 +214,7 @@ am_diag_samesite_str(request_rec *r, am_samesite_t samesite)
     case am_samesite_default: return "default";
     case am_samesite_lax:     return "lax";
     case am_samesite_strict:  return "strict";
+    case am_samesite_none:    return "none";
     default:
         return apr_psprintf(r->pool, "unknown (%d)", samesite);
     }


### PR DESCRIPTION
Starting in Chrome 80 in February 2020, cookies without the SameSite attribute set will default to SameSite=Lax. This seems to break mod_auth_mellon when using an external IdP (e.g., Okta) because the mellon-cookie is not sent with the cross-origin POST request from the IdP.

The fix is to set SameSite=None and MellonSecureCookie On. This allows the cookie to be unconditionally sent in cross-origin requests.  Mellon doesn't currently support a value of "None" for SameSite. This change implements this support.

I think long-term it would also be worth considering why Mellon needs that mellon-cookie to come back. It's initially just set to a test value of mellon-cookie=cookietest. Based on the log messages (below), it seems that Mellon assumes the user's browser doesn't support cookies if it doesn't receive this back. I think this should be a configurable setting, because with the advent of the Chrome changes, this isn't necessarily a true assumption.

`User has disabled cookies, or has lost the cookie before returning from the SAML2 login server.`

For background on the changes to Chrome, see: https://blog.chromium.org/2019/10/developers-get-ready-for-new.html