### PR TITLE
Add option to control whether or not to send the Expect Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,20 @@ MellonEnabledInvalidateSessionEndpoint On
 Default value is Off
 
 
+## Send Expect Header
+The Expect Header save an additional network round-trip and is thus a good idea when
+the request isn't extremely large and the probability for rejection is low.
+For some Apache server version, the Expect Header is not properly managed and the curl command will 
+wait for 1 sec. before sending the body of the request. 
+If the Expect Header is not present, there won't be wait time in the HTTP-Artifact binding.
+
+Here is a sample configuration to not send the Expect header:
+```ApacheConf
+MellonSendExpectHeader Off
+```
+Default value is On
+
+
 ## Probe IdP discovery 
 
 mod_auth_mellon has an IdP probe discovery service that sends HTTP GET

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -324,6 +324,10 @@ typedef struct am_dir_cfg_rec {
 
     /* Enabled the session invalidate endpoint. */
     int enabled_invalidation_session;
+
+    /* Send Expect Header. */
+    int send_expect_header;
+
 } am_dir_cfg_rec;
 
 /* Bitmask for PAOS service options */

--- a/auth_mellon_httpclient.c
+++ b/auth_mellon_httpclient.c
@@ -483,6 +483,7 @@ int am_httpclient_post(request_rec *r, const char *uri,
     char curl_error[CURL_ERROR_SIZE];
     CURLcode res;
     struct curl_slist *ctheader;
+    am_dir_cfg_rec *cfg = am_get_dir_cfg(r);
 
     /* Initialize the data storage. */
     am_hc_block_header_init(&bh, r->pool);
@@ -536,6 +537,11 @@ int am_httpclient_post(request_rec *r, const char *uri,
                                      content_type,
                                      NULL
                                      ));
+
+    /* Check if the send expect header is "off". */
+    if (cfg->send_expect_header == 0) {
+        ctheader = curl_slist_append(ctheader, "Expect:");
+    }
 
     /* Set headers. */
     res = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, ctheader);


### PR DESCRIPTION
By default, curl will add the "Expect" Header and will wait for 1 sec before sending the body of the message during the HTTP-Artifact binding if the IDP server do not response to the Expect-100Continue.

If the IDP called by the mellon-curl/HTTP-Artifact is an Apache server, the Apache do not support the Expect Header and the Expect Header will be ignored. So the curl will wait for 1 sec (for nothing) before sending the body.

So, to improve performance with the HTTP-Artifact binding, let's have an option to unset the Expect Header of the curl (MellonDisabledCurlExpectLogic Off/On). (for those where the IDP is in front of an Apache server)

> Disabling the Expect Logic saves an additional network round-trip and is thus
> a good idea when the request isn't extremely large and the probability for rejection is low.
> 

/Eric.
