### PR TITLE
Avoid always set same site

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ MellonDiagnosticsEnable Off
         # Some browsers will reject cookies if SameSite is specified.
         # MELLON_DISABLE_SAMESITE environment variable suppresses 
         # unnecessary setting of SameSite cookies
-        # SetEnvIf User-Agent ^.*Chrome\/5[1-9|6[0-6].* MELLON_DISABLE_SAMESITE]
+        # SetEnvIf User-Agent ^.*Chrome\/5[1-9]|6[0-6].* MELLON_DISABLE_SAMESITE
         # SetEnvIf User-Agent ^.*Android.*UCBrowser\/[0-9]|1[0-1].*$ MELLON_DISABLE_SAMESITE
         # SetEnvIf User-Agent ^.*Android.*UCBrowser\/12\.[0-9]|1[0-3].*$ MELLON_DISABLE_SAMESITE
         # SetEnvIf User-Agent ^.*Android.*UCBrowser\/12\.13\.[0-1].*$ MELLON_DISABLE_SAMESITE

--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ MellonDiagnosticsEnable Off
         # MELLON_DISABLE_SAMESITE environment variable suppresses 
         # unnecessary setting of SameSite cookies
         # SetEnvIf User-Agent ^.*Chrome\/5[1-9|6[0-6].* MELLON_DISABLE_SAMESITE]
-        # SetEnvIf User-Agent ^.*UCBrowser\/[0-9]|1[0-1].*$ MELLON_DISABLE_SAMESITE
-        # SetEnvIf User-Agent ^.*UCBrowser\/12\.[0-9]|1[0-3].*$ MELLON_DISABLE_SAMESITE
-        # SetEnvIf User-Agent ^.*UCBrowser\/12\.13\.[0-1].*$ MELLON_DISABLE_SAMESITE
+        # SetEnvIf User-Agent ^.*Android.*UCBrowser\/[0-9]|1[0-1].*$ MELLON_DISABLE_SAMESITE
+        # SetEnvIf User-Agent ^.*Android.*UCBrowser\/12\.[0-9]|1[0-3].*$ MELLON_DISABLE_SAMESITE
+        # SetEnvIf User-Agent ^.*Android.*UCBrowser\/12\.13\.[0-1].*$ MELLON_DISABLE_SAMESITE
         # SetEnvIf User-Agent ^.*iPhone; CPU iPhone OS 1[0-2].*$ MELLON_DISABLE_SAMESITE
         # SetEnvIf User-Agent ^.*iPad; CPU OS 1[0-2].*$ MELLON_DISABLE_SAMESITE
         # SetEnvIf User-Agent ^.*iPod touch; CPU iPhone OS 1[0-2].*$ MELLON_DISABLE_SAMESITE

--- a/README.md
+++ b/README.md
@@ -226,6 +226,18 @@ MellonDiagnosticsEnable Off
         # Default: not set
         # MellonCookieSameSite lax
 
+        # Some browsers will reject cookies if SameSite is specified.
+        # MELLON_DISABLE_SAMESITE environment variable suppresses 
+        # unnecessary setting of SameSite cookies
+        # SetEnvIf User-Agent ^.*Chrome\/5[1-9|6[0-6].* MELLON_DISABLE_SAMESITE]
+        # SetEnvIf User-Agent ^.*UCBrowser\/[0-9]|1[0-1].*$ MELLON_DISABLE_SAMESITE
+        # SetEnvIf User-Agent ^.*UCBrowser\/12\.[0-9]|1[0-3].*$ MELLON_DISABLE_SAMESITE
+        # SetEnvIf User-Agent ^.*UCBrowser\/12\.13\.[0-1].*$ MELLON_DISABLE_SAMESITE
+        # SetEnvIf User-Agent ^.*iPhone; CPU iPhone OS 1[0-2].*$ MELLON_DISABLE_SAMESITE
+        # SetEnvIf User-Agent ^.*iPad; CPU OS 1[0-2].*$ MELLON_DISABLE_SAMESITE
+        # SetEnvIf User-Agent ^.*iPod touch; CPU iPhone OS 1[0-2].*$ MELLON_DISABLE_SAMESITE
+        # SetEnvIf User-Agent ^.*Macintosh; Intel Mac OS X.*Version\/1[0-2].*Safari.*$ MELLON_DISABLE_SAMESITE
+
         # MellonUser selects which attribute we should use for the username.
         # The username is passed on to other apache modules and to the web
         # page the user visits. NAME_ID is an attribute which we set to

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -96,6 +96,11 @@ typedef enum {
 } am_diag_flags_t;
 #endif
 
+
+/* Disable SameSite Environment Value */
+#define AM_DISABLE_SAMESITE_ENV_VAR "MELLON_DISABLE_SAMESITE"
+
+
 /* This is the length of the id we use (for session IDs and
  * replaying POST data).
  */

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -59,6 +59,7 @@ static const char *am_cookie_params(request_rec *r)
     const char *cookie_domain = ap_get_server_name(r);
     const char *cookie_path = "/";
     const char *cookie_samesite = "";
+    const char *env_var_value = NULL;
     am_dir_cfg_rec *cfg = am_get_dir_cfg(r);
 
     if (cfg->cookie_domain) {
@@ -69,12 +70,21 @@ static const char *am_cookie_params(request_rec *r)
         cookie_path = cfg->cookie_path;
     }
 
-    if (cfg->cookie_samesite == am_samesite_lax) {
-        cookie_samesite = "; SameSite=Lax";
-    } else if (cfg->cookie_samesite == am_samesite_strict) {
-        cookie_samesite = "; SameSite=Strict";
-    } else if (cfg->cookie_samesite == am_samesite_none) {
-        cookie_samesite = "; SameSite=None";
+    if (r->subprocess_env != NULL){
+        env_var_value = apr_table_get(r->subprocess_env,
+                        AM_DISABLE_SAMESITE_ENV_VAR);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                     "%s : %s", AM_DISABLE_SAMESITE_ENV_VAR, env_var_value);
+    }
+
+    if (env_var_value == NULL){
+        if (cfg->cookie_samesite == am_samesite_lax) {
+            cookie_samesite = "; SameSite=Lax";
+        } else if (cfg->cookie_samesite == am_samesite_strict) {
+            cookie_samesite = "; SameSite=Strict";
+        } else if (cfg->cookie_samesite == am_samesite_none) {
+            cookie_samesite = "; SameSite=None";
+        }
     }
 
     secure_cookie = cfg->secure;


### PR DESCRIPTION
SameSite=None is not always work better.
https://www.chromium.org/updates/same-site/incompatible-clients

These browsers reject cookie if SameSite=None set.
* chrome 51-66
* android UCBrowser 12.13.2 before

These browsers set SameSite=strick cookie if SameSite=None set.
* MacOS 10.14
* iOS12