### PR TITLE
Cache SAML Response replay message on new sessions

### DIFF
--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -379,7 +379,8 @@ typedef struct am_cache_entry_t {
 
 typedef enum { 
     AM_CACHE_SESSION, 
-    AM_CACHE_NAMEID 
+    AM_CACHE_NAMEID,
+    AM_CACHE_ASSERTIONID
 } am_cache_key_t;
 
 /* Type for configuring environment variable names */
@@ -482,6 +483,8 @@ const char *am_cache_get_lasso_session(am_cache_entry_t *session);
 am_cache_entry_t *am_get_request_session(request_rec *r);
 am_cache_entry_t *am_get_request_session_by_nameid(request_rec *r, 
                                                    char *nameid);
+am_cache_entry_t *am_get_request_session_by_assertionid(request_rec *r,
+                                                        char *assertionid);
 am_cache_entry_t *am_new_request_session(request_rec *r);
 void am_release_request_session(request_rec *r, am_cache_entry_t *session);
 void am_delete_request_session(request_rec *r, am_cache_entry_t *session);

--- a/auth_mellon_cache.c
+++ b/auth_mellon_cache.c
@@ -1,7 +1,7 @@
 /*
  *
  *   auth_mellon_cache.c: an authentication apache module
- *   Copyright © 2003-2007 UNINETT (http://www.uninett.no/)
+ *   Copyright Â© 2003-2007 UNINETT (http://www.uninett.no/)
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -71,7 +71,7 @@ void am_cache_init(am_mod_cfg_rec *mod_cfg)
  *
  * Parameters:
  *  request_rec *r       The request we are processing.
- *  am_cache_key_t type  AM_CACHE_SESSION or AM_CACHE_NAMEID
+ *  am_cache_key_t type  AM_CACHE_SESSION, AM_CACHE_NAMEID or AM_CACHE_ASSERTIONID
  *  const char *key      The session key or user
  *
  * Returns:
@@ -98,6 +98,7 @@ am_cache_entry_t *am_cache_lock(request_rec *r,
             return NULL;
         break;
     case AM_CACHE_NAMEID:
+    case AM_CACHE_ASSERTIONID:
         break;
     default:
         return NULL;
@@ -134,6 +135,10 @@ am_cache_entry_t *am_cache_lock(request_rec *r,
         case AM_CACHE_NAMEID:
             /* tablekey may be NULL */
             tablekey = am_cache_env_fetch_first(e, "NAME_ID");
+            break;
+        case AM_CACHE_ASSERTIONID:
+            /* tablekey may be NULL */
+            tablekey = am_cache_env_fetch_first(e, "ASSERTION_ID");
             break;
         default:
             tablekey = NULL;

--- a/auth_mellon_diagnostics.c
+++ b/auth_mellon_diagnostics.c
@@ -809,9 +809,10 @@ const char *
 am_diag_cache_key_type_str(am_cache_key_t key_type)
 {
     switch(key_type) {
-    case AM_CACHE_SESSION: return "session";
-    case AM_CACHE_NAMEID : return "name id";
-    default:               return "unknown";
+    case AM_CACHE_SESSION:      return "session";
+    case AM_CACHE_NAMEID:       return "name id";
+    case AM_CACHE_ASSERTIONID:  return "assertion id";
+    default:                    return "unknown";
     }
 }
 
@@ -1108,6 +1109,7 @@ am_diag_log_cache_entry(request_rec *r, int level, am_cache_entry_t *entry,
     am_req_cfg_rec *req_cfg = am_get_req_cfg(r);
 
     const char *name_id = NULL;
+    const char *assertion_id = NULL;
 
     if (!AM_DIAG_ENABLED(diag_cfg)) return;
     if (!am_diag_initialize_req(r, diag_cfg, req_cfg)) return;
@@ -1118,6 +1120,7 @@ am_diag_log_cache_entry(request_rec *r, int level, am_cache_entry_t *entry,
 
     if (entry) {
         name_id = am_cache_env_fetch_first(entry, "NAME_ID");
+        assertion_id = am_cache_env_fetch_first(entry, "ASSERTION_ID");
 
         apr_file_printf(diag_cfg->fd,
                         "%skey: %s\n",
@@ -1125,6 +1128,9 @@ am_diag_log_cache_entry(request_rec *r, int level, am_cache_entry_t *entry,
         apr_file_printf(diag_cfg->fd,
                         "%sname_id: %s\n",
                         indent(level+1), name_id);
+        apr_file_printf(diag_cfg->fd,
+                        "%sassertion_id: %s\n",
+                        indent(level+1), assertion_id);
         apr_file_printf(diag_cfg->fd,
                         "%sexpires: %s\n",
                         indent(level+1),

--- a/auth_mellon_session.c
+++ b/auth_mellon_session.c
@@ -1,7 +1,7 @@
 /*
  *
  *   auth_mellon_session.c: an authentication apache module
- *   Copyright © 2003-2007 UNINETT (http://www.uninett.no/)
+ *   Copyright Â© 2003-2007 UNINETT (http://www.uninett.no/)
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ APLOG_USE_MODULE(auth_mellon);
  *
  * Parameters:
  *  request_rec *r       The request we received from the user.
- *  am_cache_key_t type  AM_CACHE_SESSION or AM_CACHE_NAMEID
+ *  am_cache_key_t type  AM_CACHE_SESSION, AM_CACHE_NAMEID or AM_CACHE_ASSERTIONID
  *  const char *key      The session key or user
  *
  * Returns:
@@ -106,6 +106,21 @@ am_cache_entry_t *am_get_request_session(request_rec *r)
 am_cache_entry_t *am_get_request_session_by_nameid(request_rec *r, char *nameid)
 {
     return am_lock_and_validate(r, AM_CACHE_NAMEID, nameid);
+}
+
+/* This function gets the session associated with a user, using the Assertion ID
+ *
+ * Parameters:
+ *  request_rec *r       The request we received from the user.
+ *  char *assertionid    The AssertionID
+ *
+ * Returns:
+ *  The session associated with the user who places the request, or
+ *  NULL if we don't have a session yet.
+ */
+am_cache_entry_t *am_get_request_session_by_assertionid(request_rec *r, char *assertionid)
+{
+    return am_lock_and_validate(r, AM_CACHE_ASSERTIONID, assertionid);
 }
 
 /* This function creates a new session.


### PR DESCRIPTION
This is a vulnerability that we found.
It is possible to create several valid mellon session cookies using the same SAML reponse.
The solution is to validate if the assertion ID was already been used before creating a new session.
Ref: https://blog.netspi.com/attacking-sso-common-saml-vulnerabilities-ways-find/, "Messsage Replay"

