### PR TITLE
Set SameSite to None on test cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,15 @@ MellonDiagnosticsEnable Off
         # When using none, you should set "MellonSecureCookie On" to prevent
         # compatibility issues with newer browsers.
         # If not set, the SameSite attribute is not set on the cookie. In newer
-        # browsers, this may cause SameSite to default to "Lax"
+        # browsers, this may cause SameSite to default to "Lax".
+        # Note: Regardless of the value set here a fixed SameSite value of
+        # None is used for the cookie test. The cookie test, which is performed
+        # with a static value, should detect whether the user's client accepts
+        # cookies or not before the auth_mellon session is established and thus
+        # avoid a redirect loop. Using a fixed SameSite value of None ensures
+        # that the cookie with the static value does not get lost in the
+        # HTTP-POST binding request issued by the autosubmit form returned by
+        # the IDP.
         # Default: not set
         # MellonCookieSameSite lax
 

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -100,6 +100,9 @@ typedef enum {
 /* Disable SameSite Environment Value */
 #define AM_DISABLE_SAMESITE_ENV_VAR "MELLON_DISABLE_SAMESITE"
 
+/* Force setting SameSite to None */
+#define AM_FORCE_SAMESITE_NONE_NOTE "MELLON_FORCE_SAMESITE_NONE"
+
 
 /* This is the length of the id we use (for session IDs and
  * replaying POST data).

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -78,7 +78,11 @@ static const char *am_cookie_params(request_rec *r)
     }
 
     if (env_var_value == NULL){
-        if (cfg->cookie_samesite == am_samesite_lax) {
+        if ((cfg->cookie_samesite != am_samesite_default) &&
+            (apr_table_get(r->notes, AM_FORCE_SAMESITE_NONE_NOTE) != NULL)) {
+            cookie_samesite = "; SameSite=None";
+        }
+        else if (cfg->cookie_samesite == am_samesite_lax) {
             cookie_samesite = "; SameSite=Lax";
         } else if (cfg->cookie_samesite == am_samesite_strict) {
             cookie_samesite = "; SameSite=Strict";

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -3261,8 +3261,13 @@ static int am_send_login_authn_request(request_rec *r, const char *idp,
     /* Add cookie for cookie test. We know that we should have
      * a valid cookie when we return from the IdP after SP-initiated
      * login.
+     * Ensure that SameSite is set to None for this cookie if SameSite
+     * is allowed to be set as the cookie otherwise gets lost on
+     * HTTP-POST binding messages.
      */
+    apr_table_setn(r->notes, AM_FORCE_SAMESITE_NONE_NOTE, "1");
     am_cookie_set(r, "cookietest");
+    apr_table_unset(r->notes, AM_FORCE_SAMESITE_NONE_NOTE);
 
     server = am_get_lasso_server(r);
     if(server == NULL) {


### PR DESCRIPTION
If the SameSite cookie attribute is to be set because
MellonCookieSameSite is configured and MELLON_DISABLE_SAMESITE not set
for this particular request set it to None for the test cookie.
This ensures that the test cookie with the static test content does not
get lost in the HTTP-POST binding request issued by the autosubmit form
returned by the IDP.
Addresses #20

* auth_mellon.h: Add AM_FORCE_SAMESITE_NONE_NOTE

* auth_mellon_handler.c (am_send_login_authn_request): Set request note
  to set SameSite to None if appropriate.

* auth_mellon_cookie.c (am_cookie_params): Set SameSite to None if
  requested via request note.