### PR TITLE
Improve error msg when MellonCookieSameSite has an invalid value

### DIFF
--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -590,7 +590,7 @@ static const char *am_set_samesite_slot(cmd_parms *cmd,
     } else if(!strcasecmp(arg, "none")) {
         d->cookie_samesite = am_samesite_none;
     } else {
-        return "The MellonCookieSameSite parameter must be 'lax' or 'strict'";
+        return "The MellonCookieSameSite parameter must be 'lax', 'none' or 'strict'";
     }
 
     return NULL;


### PR DESCRIPTION
Previously the error message would only say lax or strict is allowed.
This is a minor issue because the message would only have been printed
when the admin did a typo in the first place.

Spotted by Kyle Walker.