### PR TITLE
Fix am_mod_cfg_rec not being reused.(#36)

### DIFF
--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -2207,14 +2207,14 @@ void *auth_mellon_server_config(apr_pool_t *p, server_rec *s)
     /* we want to keeep our global configuration of shared memory and
      * mutexes, so we try to find it in the userdata before doing anything
      * else */
-    apr_pool_userdata_get((void **)&mod, key, p);
+    apr_pool_userdata_get((void **)&mod, key, s->process->pool);
     if (mod) {
         srv->mc = mod;
         return srv;
     }
 
     /* the module has not been initiated at all */
-    mod = apr_palloc(p, sizeof(*mod));
+    mod = apr_palloc(s->process->pool, sizeof(*mod));
 
     mod->cache_size = 100;  /* ought to be enough for everybody */
     mod->lock_file  = "/var/run/mod_auth_mellon.lock";
@@ -2232,7 +2232,7 @@ void *auth_mellon_server_config(apr_pool_t *p, server_rec *s)
     mod->cache      = NULL;
     mod->lock       = NULL;
 
-    apr_pool_userdata_set(mod, key, apr_pool_cleanup_null, p);
+    apr_pool_userdata_set(mod, key, apr_pool_cleanup_null, s->process->pool);
 
     srv->mc = mod;
 

--- a/mod_auth_mellon.c
+++ b/mod_auth_mellon.c
@@ -89,7 +89,7 @@ static int am_global_init(apr_pool_t *conf, apr_pool_t *log,
      * initialized.
      */
     mod->init_cache_size = mod->cache_size;
-    mod->init_lock_file = apr_pstrdup(conf, mod->lock_file);
+    mod->init_lock_file = apr_pstrdup(s->process->pool, mod->lock_file);
     mod->init_entry_size = mod->entry_size;
     if (mod->init_entry_size < AM_CACHE_MIN_ENTRY_SIZE) {
         mod->init_entry_size = AM_CACHE_MIN_ENTRY_SIZE;
@@ -100,7 +100,7 @@ static int am_global_init(apr_pool_t *conf, apr_pool_t *log,
 
 
     /* Create the shared memory, exit if it fails. */
-    rv = apr_shm_create(&(mod->cache), mem_size, NULL, conf);
+    rv = apr_shm_create(&(mod->cache), mem_size, NULL, s->process->pool);
 
     if (rv != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
@@ -117,7 +117,7 @@ static int am_global_init(apr_pool_t *conf, apr_pool_t *log,
     rv = apr_global_mutex_create(&(mod->lock),
                                  mod->init_lock_file,
                                  APR_LOCK_DEFAULT,
-                                 conf);
+                                 s->process->pool);
 
     if (rv != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,


### PR DESCRIPTION
Reuse am_mod_cfg_rec.
mellon Sessions are not lost on httpd restart (signal: HUP, USR1).
However, the cache size is not changed.