### PR TITLE
Add the session idle timeout fonctionnality

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,13 @@ MellonDiagnosticsEnable Off
         # Default: MellonSessionLength 86400
         MellonSessionLength 86400
 
+        # MellonSessionIdleTimeout represents the amount of time a user
+        # can be inactive before the user's session times out in seconds.
+        # This parameter is disabled by default to maintain backward 
+        # compatibility.
+        # Default: MellonSessionIdleTimeout -1 (disabled)
+        MellonSessionIdleTimeout -1
+
         # MellonNoCookieErrorPage is the full path to a page which
         # mod_auth_mellon will redirect the user to if he returns from the
         # IdP without a cookie with a session id.

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -279,6 +279,9 @@ typedef struct am_dir_cfg_rec {
     /* Maximum number of seconds a session is valid for. */
     int session_length;
 
+    /* Maximum number of seconds a session idle timeout is valid for. */
+    int session_idle_timeout;
+
     /* No cookie error page. */
     const char *no_cookie_error_page;
 
@@ -366,6 +369,7 @@ typedef struct am_cache_entry_t {
     am_cache_storage_t cookie_token;
     apr_time_t access;
     apr_time_t expires;
+    apr_time_t idle_timeout;
     int logged_in;
     unsigned short size;
     am_cache_storage_t user;
@@ -471,6 +475,7 @@ am_cache_entry_t *am_cache_new(request_rec *r,
 void am_cache_unlock(request_rec *r, am_cache_entry_t *entry);
 
 void am_cache_update_expires(request_rec *r, am_cache_entry_t *t, apr_time_t expires);
+void am_cache_update_idle_timeout(request_rec *r, am_cache_entry_t *t, int session_idle_timeout);
 
 void am_cache_env_populate(request_rec *r, am_cache_entry_t *session);
 int am_cache_env_append(am_cache_entry_t *session,

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -1550,6 +1550,14 @@ const command_rec auth_mellon_commands[] = {
         " to 86400 seconds (1 day)."
         ),
     AP_INIT_TAKE1(
+        "MellonSessionIdleTimeout",
+        ap_set_int_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, session_idle_timeout),
+        OR_AUTHCFG,
+        "Amount of time a user can be inactive before the user's session times out. Defaults"
+        " to -1 seconds (disabled)."
+        ),
+    AP_INIT_TAKE1(
         "MellonNoCookieErrorPage",
         ap_set_string_slot,
         (void *)APR_OFFSETOF(am_dir_cfg_rec, no_cookie_error_page),
@@ -1869,6 +1877,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->endpoint_path = default_endpoint_path;
 
     dir->session_length = -1; /* -1 means use default. */
+    dir->session_idle_timeout = -1; /* -1 means disabled. */
 
     dir->no_cookie_error_page = NULL;
     dir->no_success_error_page = NULL;
@@ -2051,6 +2060,10 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->session_length = (add_cfg->session_length != -1 ?
                                add_cfg->session_length :
                                base_cfg->session_length);
+
+    new_cfg->session_idle_timeout = (add_cfg->session_idle_timeout != -1 ?
+                                     add_cfg->session_idle_timeout :
+                                     base_cfg->session_idle_timeout);
 
     new_cfg->no_cookie_error_page = (add_cfg->no_cookie_error_page != NULL ?
                                      add_cfg->no_cookie_error_page :

--- a/auth_mellon_diagnostics.c
+++ b/auth_mellon_diagnostics.c
@@ -584,6 +584,9 @@ am_diag_log_dir_cfg(request_rec *r, int level, am_dir_cfg_rec *cfg,
                     "%sMellonSessionLength (session_length): %d\n",
                     indent(level+1), cfg->session_length);
     apr_file_printf(diag_cfg->fd,
+                    "%sMellonSessionIdleTimeout (session_idle_timeout): %d\n",
+                    indent(level+1), cfg->session_idle_timeout);
+    apr_file_printf(diag_cfg->fd,
                     "%sMellonNoCookieErrorPage (no_cookie_error_page): %s\n",
                     indent(level+1), cfg->no_cookie_error_page);
     apr_file_printf(diag_cfg->fd,
@@ -1135,6 +1138,10 @@ am_diag_log_cache_entry(request_rec *r, int level, am_cache_entry_t *entry,
                         "%sexpires: %s\n",
                         indent(level+1),
                         am_diag_time_t_to_8601(r, entry->expires));
+        apr_file_printf(diag_cfg->fd,
+                        "%sidle_timeout: %s\n",
+                        indent(level+1),
+                        am_diag_time_t_to_8601(r, entry->idle_timeout));
         apr_file_printf(diag_cfg->fd,
                         "%saccess: %s\n",
                         indent(level+1),

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -1714,6 +1714,9 @@ static int add_attributes(am_cache_entry_t *session, request_rec *r,
                                 + apr_time_make(dir_cfg->session_length, 0));
     }
 
+    /* Set the idle timeout to whatever is set by MellonSessionIdleTimeout. */
+    am_cache_update_idle_timeout(r, session, dir_cfg->session_idle_timeout);
+
     /* Save session NAME_ID information. */
     ret = am_cache_env_append(session, "NAME_ID", name_id);
     if(ret != OK) {
@@ -3873,6 +3876,8 @@ int am_auth_mellon_user(request_rec *r)
             return return_code;
         }
 
+        /* Update the idle timeout to whatever is set by MellonSessionIdleTimeout. */
+        am_cache_update_idle_timeout(r, session, dir->session_idle_timeout);
 
         /* The user has been authenticated, and we can now populate r->user
          * and the r->subprocess_env with values from the session store.
@@ -3897,6 +3902,9 @@ int am_auth_mellon_user(request_rec *r)
 
             am_diag_printf(r, "%s am_enable_info, have valid session\n",
                            __func__);
+
+            /* Update the idle timeout to whatever is set by MellonSessionIdleTimeout. */
+            am_cache_update_idle_timeout(r, session, dir->session_idle_timeout);
 
             /* The user is authenticated and has access to the resource.
              * Now we populate the environment with information about


### PR DESCRIPTION
The Idle Session Timeout (Inactivity) represents the amount of time a user can be inactive before the user's session times out in seconds.
The Idle Timeout is working with the session length(lifetime) to managed the amount of time the user session cookie­ expired.
This parameter is disabled by default to maintain backward compatibility.