### PR TITLE
fix build for libxml and xmlsec

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -42,7 +42,7 @@ DISTFILES=$(SRC) \
 all:	mod_auth_mellon.la
 
 mod_auth_mellon.la: $(SRC) auth_mellon.h auth_mellon_compat.h
-	@APXS2@ -Wc,"-std=c99 @MELLON_CFLAGS@ @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@ @CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
+	@APXS2@ -Wc,"-std=c99 @MELLON_CFLAGS@ @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@ @CFLAGS@ @LIBXML2_CFLAGS@ @XMLSEC_CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@ @LIBXML2_LIBS@ @XMLSEC_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
 
 
 # Building configure (for distribution)

--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,16 @@ AC_SUBST(GLIB_LIBS)
 
 AC_SUBST(MELLON_CFLAGS)
 
+#include <libxml/uri.h>
+PKG_CHECK_MODULES(LIBXML2, libxml-2.0)
+AC_SUBST(LIBXML2_CFLAGS)
+AC_SUBST(LIBXML2_LIBS)
+
+#include <xmlsec/xmlenc.h>
+PKG_CHECK_MODULES(XMLSEC, xmlsec1-openssl)
+AC_SUBST(XMLSEC_CFLAGS)
+AC_SUBST(XMLSEC_LIBS)
+
 # Test to see if we can include lasso/utils.h
 # AC_CHECK_HEADER won't work correctly unless we specifiy the include directories
 # found in the LASSO_CFLAGS. Save and restore CFLAGS and CPPFLAGS.


### PR DESCRIPTION
`mod_auth_mellon` doesn't build on the distro I use without some fixes.