### PR TITLE
Adjusting the setting of SameSite property for CookieTest

### DIFF
--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -78,16 +78,13 @@ static const char *am_cookie_params(request_rec *r)
     }
 
     if (env_var_value == NULL){
-        if ((cfg->cookie_samesite != am_samesite_default) &&
-            (apr_table_get(r->notes, AM_FORCE_SAMESITE_NONE_NOTE) != NULL)) {
+        if (cfg->cookie_samesite == am_samesite_none ||
+                apr_table_get(r->notes, AM_FORCE_SAMESITE_NONE_NOTE) != NULL){
             cookie_samesite = "; SameSite=None";
-        }
-        else if (cfg->cookie_samesite == am_samesite_lax) {
+        } else if (cfg->cookie_samesite == am_samesite_lax) {
             cookie_samesite = "; SameSite=Lax";
         } else if (cfg->cookie_samesite == am_samesite_strict) {
             cookie_samesite = "; SameSite=Strict";
-        } else if (cfg->cookie_samesite == am_samesite_none) {
-            cookie_samesite = "; SameSite=None";
         }
     }
 


### PR DESCRIPTION
Fixing the issue where the cookie test SameSite was set to None **only** if the `MellonCookieSameSite `was set to something other than default instead of **regardless** of the value (as said in main page)

Addresses #20 and likely #47