### PR TITLE
Add encryption certificate to generated metadata

### DIFF
--- a/mellon_create_metadata.sh
+++ b/mellon_create_metadata.sh
@@ -77,6 +77,13 @@ CERT="$(grep -v '^-----' "$OUTFILE.cert")"
 cat >"$OUTFILE.xml" <<EOF
 <EntityDescriptor entityID="$ENTITYID" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true">
+    <KeyDescriptor use="encryption">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>$CERT</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </KeyDescriptor>
     <KeyDescriptor use="signing">
       <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
         <ds:X509Data>


### PR DESCRIPTION
Add our certificate as being eligible for encryption as well as signing (to make idPs that require encryption happy)