### PR TITLE
Add support for persistent sessions across apache restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ MellonCacheSize 100
 # be used.
 # Default: MellonCacheEntrySize 196608
 
+# MellonCacheFile is the full path to a file used as session cache
+# shared memory segment name. Defining it will enable peristent
+# session cache across httpd restarts, until the shared memory segment
+# is removed, or a change is made to MellonCacheSizeMellonCacheSize or
+# MellonCacheEntrySize.
+# Default: unset, which means sessions are not persistent
+# MellonCacheFile "/var/run/mod_auth_mellon.cache"
+
 # MellonLockFile is the full path to a file used for synchronizing access
 # to the session data. The path should only be used by one instance of
 # apache at a time. The server must be restarted before any changes to this

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -126,6 +126,7 @@ typedef enum {
 typedef struct am_mod_cfg_rec {
     int cache_size;
     const char *lock_file;
+    const char *cache_file;
     const char *post_dir;
     apr_time_t post_ttl;
     int post_count;
@@ -464,7 +465,7 @@ void am_cookie_delete(request_rec *r);
 const char *am_cookie_token(request_rec *r);
 
 
-void am_cache_init(am_mod_cfg_rec *mod_cfg);
+int am_cache_init(apr_pool_t *conf, apr_pool_t *tmp, server_rec *s);
 am_cache_entry_t *am_cache_lock(request_rec *r, 
                                 am_cache_key_t type, const char *key);
 const char *am_cache_entry_get_string(am_cache_entry_t *e,

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -1337,6 +1337,14 @@ const command_rec auth_mellon_commands[] = {
         " take effect. The default value is 192KiB."
         ),
     AP_INIT_TAKE1(
+        "MellonCacheFile",
+        am_set_module_config_file_slot,
+        (void *)APR_OFFSETOF(am_mod_cfg_rec, cache_file),
+        RSRC_CONF,
+        "The cache file for session resume after resstart."
+        " Default value is none (no session resume)."
+        ),
+    AP_INIT_TAKE1(
         "MellonLockFile",
         am_set_module_config_file_slot,
         (void *)APR_OFFSETOF(am_mod_cfg_rec, lock_file),

--- a/mod_auth_mellon.c
+++ b/mod_auth_mellon.c
@@ -27,6 +27,7 @@
 APLOG_USE_MODULE(auth_mellon);
 #endif
 
+
 /* This function is called after the configuration of the server is parsed
  * (it's a post-config hook).
  *
@@ -48,7 +49,6 @@ APLOG_USE_MODULE(auth_mellon);
 static int am_global_init(apr_pool_t *conf, apr_pool_t *log,
                           apr_pool_t *tmp, server_rec *s)
 {
-    apr_size_t        mem_size;
     am_mod_cfg_rec   *mod;
     int rv;
     const char userdata_key[] = "auth_mellon_init";
@@ -95,22 +95,8 @@ static int am_global_init(apr_pool_t *conf, apr_pool_t *log,
         mod->init_entry_size = AM_CACHE_MIN_ENTRY_SIZE;
     }
 
-    /* find out the memory size of the cache */
-    mem_size = mod->init_entry_size * mod->init_cache_size;
-
-
-    /* Create the shared memory, exit if it fails. */
-    rv = apr_shm_create(&(mod->cache), mem_size, NULL, conf);
-
-    if (rv != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                     "shm_create: Error [%d] \"%s\"", rv,
-                     apr_strerror(rv, buffer, sizeof(buffer)));
+    if (am_cache_init(conf, tmp, s) != OK)
         return !OK;
-    }
-
-    /* Initialize the session table. */
-    am_cache_init(mod);
 
     /* Now create the mutex that we need for locking the shared memory, then
      * test for success. we really need this, so we exit on failure. */


### PR DESCRIPTION
This is done by using named shared memory, so that we can find and reload the session cache after apache restart.

The feature is disabled by default, and can be enabled by specifying a MellonCacheFile directive.