### PR TITLE
Fix compatibility with mod_rpaf/mod_remoteip + follow Apache Module Dev Guide

### DIFF
--- a/auth_mellon_compat.h
+++ b/auth_mellon_compat.h
@@ -38,7 +38,7 @@ static inline const char *am_compat_request_ip(request_rec *r) {
 #if (AP_SERVER_MAJORVERSION_NUMBER == 2) && (AP_SERVER_MINORVERSION_NUMBER < 4)
     return r->connection->remote_ip;
 #else
-    return r->connection->client_ip;
+    return r->useragent_ip;
 #endif
 }
 


### PR DESCRIPTION
Today, mod_auth_mellon is comparing the wrong IP address against the IP sent to us by the IdP.  This results in MellonSubjectConfirmationDataAddressCheck failing in a scenario where you are using mod_rpaf or mod_remoteip to update the clients IP address.  This is a common scenario when Apache is behind a load balancer.

In order to fix this, we need to use the useragent_ip variable, instead of connection->client_ip.

The Apache module development guide also recommends this:
https://httpd.apache.org/docs/trunk/developer/modguide.html