### PR TITLE
Fix mod_auth_mellon failures behind SSL terminating reverse proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,20 @@ MellonDiagnosticsEnable Off
         # Default: rsa-sha256
         # MellonSignatureMethod
 
+        # Force all generated URLs to be using HTTPS, not HTTP, regardless of the detected
+        # inbound protocol. This is really useful if mod_auth_mellon is running on a server which
+        # has an SSL reverse proxy sitting in front of it. Because the SSL connection terminates
+        # at the proxy, Apache needs to be explicitly told "yes, this is really HTTPS, even though
+        # you can't detect it".
+        #
+        # Note: This configuration variable is NOT "force use of HTTPS to my server for inbound
+        # connections". That can be done in a variety of ways with the base Apache configuration.
+        # This directive only deals with the case where Apache can't autodetect the scheme used
+        # by the client correctly.
+        #
+        # Default: Off
+        # MellonForceHttpsUrlRewrites On
+
 </Location>
 ```
 

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -334,6 +334,9 @@ typedef struct am_dir_cfg_rec {
     /* Send Expect Header. */
     int send_expect_header;
 
+    /* Whether to force conversion of generated HTTP URLs to HTTPS */
+    int force_https_rewrites;
+
 } am_dir_cfg_rec;
 
 /* Bitmask for PAOS service options */

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -118,6 +118,9 @@ static const int default_enabled_invalidation_session = 0;
  */
 static const int default_send_expect_header = 1;
 
+/* By default, do not force HTTP URLs to be rewritten to be HTTPS. */
+static const int default_force_https_rewrites = 0;
+
 /* This function handles configuration directives which set a 
  * multivalued string slot in the module configuration (the destination
  * strucure is a hash).
@@ -1805,6 +1808,15 @@ const command_rec auth_mellon_commands[] = {
         "Send the Expect Header. Default is 'on'."
         ),
 
+    AP_INIT_FLAG(
+        "MellonForceHttpsUrlRewrites",
+        ap_set_flag_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, force_https_rewrites),
+        OR_AUTHCFG,
+        "Whether to force conversion of generated HTTP URLs to HTTPS [on|off]"
+        " Default value is \"off\"."
+        ),
+
     {NULL}
 };
 
@@ -1915,6 +1927,8 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->enabled_invalidation_session = default_enabled_invalidation_session;
 
     dir->send_expect_header = default_send_expect_header;
+
+    dir->force_https_rewrites = default_force_https_rewrites;
 
     return dir;
 }
@@ -2186,6 +2200,11 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
         (add_cfg->send_expect_header != default_send_expect_header ?
          add_cfg->send_expect_header :
          base_cfg->send_expect_header);
+
+    new_cfg->force_https_rewrites =
+        (add_cfg->force_https_rewrites != default_force_https_rewrites ?
+         add_cfg->force_https_rewrites :
+         base_cfg->force_https_rewrites);
 
     return new_cfg;
 }

--- a/auth_mellon_diagnostics.c
+++ b/auth_mellon_diagnostics.c
@@ -664,6 +664,10 @@ am_diag_log_dir_cfg(request_rec *r, int level, am_dir_cfg_rec *cfg,
                     "%sMellonECPSendIDPList (ecp_send_idplist): %s\n",
                     indent(level+1), CFG_VALUE(cfg, ecp_send_idplist) ? "On":"Off");
 
+    apr_file_printf(diag_cfg->fd,
+                    "%sMellonForceHttpsUrlRewrites (force_https_rewrites): %s\n",
+                    indent(level+1), CFG_VALUE(cfg, force_https_rewrites) ? "On":"Off");
+
     for (n_items = 0; cfg->redirect_domains[n_items] != NULL; n_items++);
     apr_file_printf(diag_cfg->fd,
                     "%sMellonRedirectDomains (redirect_domains): %d items\n",

--- a/mod_auth_mellon.c
+++ b/mod_auth_mellon.c
@@ -205,6 +205,13 @@ static int am_create_request(request_rec *r)
 }
 
 
+static const char *am_http_scheme(const request_rec *r)
+{
+    am_dir_cfg_rec *d = am_get_dir_cfg(r);
+    return d->force_https_rewrites ? "https" : NULL;
+}
+
+
 static void register_hooks(apr_pool_t *p)
 {
     /* Our handler needs to run before mod_proxy so that it can properly
@@ -218,6 +225,7 @@ static void register_hooks(apr_pool_t *p)
     ap_hook_post_config(am_global_init, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_child_init(am_child_init, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_create_request(am_create_request, NULL, NULL, APR_HOOK_MIDDLE);
+    ap_hook_http_scheme(am_http_scheme, NULL, NULL, APR_HOOK_MIDDLE);
 
     /* Add the hook to handle requests to the mod_auth_mellon endpoint.
      *


### PR DESCRIPTION
This PR aims to solve the same problem posed in PR #33, where the Apache server that mod_auth_mellon is running on is behind a reverse proxy that terminates the SSL connection (meaning it's plain HTTP between the reverse proxy and the server mod_auth_mellon is running on). This causes Apache to believe it is running plain HTTP, hence mod_auth_mellon (using Apache APIs) generates URLs for things like `ReturnTo` and `RelayState` set with the wrong protocol / scheme.

The main objection to PR #33 was the security considerations of relying on an HTTP header to determine whether the server should alter this or not. The patch @smartalock put forward relies on the reverse proxy injecting a header in the request, which works, but perhaps isn't the best way.

Instead, this PR adds the MellonForceHttpsUrlRewrites configuration directive. This makes the behaviour a configuration file element, set by the admin, fixing the security issue above.

This works for cases where you can't set ServerName (ie. it has several reverse proxies in front of it). Edge case, I know. But in SimpleSAMLphp land (which I know @thijskh is familiar with) we've done this by setting the [baseUrl](https://github.com/simplesamlphp/simplesamlphp/blob/52afcfbaf71def9049adcb20e60f358cd53bd4db/config/config.php.dist#L55) dynamically in config.php (in PHP code) to cover up for this case, which of course you can't do here (ServerName can't be set per-request). So, this PR would be the next best thing.