### PR TITLE
Remove compatibility with lasso before 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ mod_auth_mellon has four dependencies:
  * pkg-config
  * Apache (>=2.0)
  * OpenSSL
- * lasso (>=2.1)
+ * lasso (>=2.4)
 
 You will also require development headers and tools for all of the
 dependencies.

--- a/README.md
+++ b/README.md
@@ -477,13 +477,6 @@ MellonDiagnosticsEnable Off
         # Default: None set.
         #MellonIdPMetadataGlob /etc/apache2/mellon/*-metadata.xml
 
-        # MellonIdpPublicKeyFile is the full path of the public key of the
-        # IdP. This parameter is optional if the public key is embedded
-        # in the IdP's metadata file, or if a certificate authority is
-        # used. This parameter cannot be used if multiple IdP are configured.
-        # Default: None set.
-        MellonIdPPublicKeyFile /etc/apache2/mellon/idp-public-key.pem
-
         # MellonIdPCAFile is the full path to the certificate of the
         # certificate authority. This can be used instead of an
         # certificate for the IdP.

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -266,7 +266,6 @@ typedef struct am_dir_cfg_rec {
     am_file_data_t *sp_private_key_file;
     am_file_data_t *sp_cert_file;
     apr_array_header_t *idp_metadata;
-    am_file_data_t *idp_public_key_file;
     am_file_data_t *idp_ca_file;
     GList *idp_ignore;
 

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -367,13 +367,6 @@ static const char *am_set_idp_string_slot(cmd_parms *cmd,
     am_file_data_t *idp_file_data = NULL;
     am_file_data_t *chain_file_data = NULL;
 
-#ifndef HAVE_lasso_server_load_metadata
-    if (chain != NULL)
-        return apr_psprintf(cmd->pool, "Cannot specify validating chain "
-                            "for %s since lasso library lacks "
-                            "lasso_server_load_metadata()", cmd->cmd->name);
-#endif /* HAVE_lasso_server_load_metadata */
-
     idp_file_data = am_file_data_new(pconf, metadata);
     if (am_file_stat(idp_file_data) != APR_SUCCESS) {
         return idp_file_data->strerror;
@@ -415,7 +408,6 @@ static const char *am_set_idp_ignore_slot(cmd_parms *cmd,
                                           int argc,
                                           char *const argv[])
 {
-#ifdef HAVE_lasso_server_load_metadata
     server_rec *s = cmd->server;
     apr_pool_t *pconf = s->process->pconf;
     am_dir_cfg_rec *cfg = (am_dir_cfg_rec *)struct_ptr;
@@ -438,13 +430,6 @@ static const char *am_set_idp_ignore_slot(cmd_parms *cmd,
     }
 
     return NULL;
-
-#else /* HAVE_lasso_server_load_metadata */
-
-    return apr_psprintf(cmd->pool, "Cannot use %s since lasso library lacks "
-                        "lasso_server_load_metadata()", cmd->cmd->name);
-
-#endif /* HAVE_lasso_server_load_metadata */
 }
 
 
@@ -1096,15 +1081,7 @@ static const char *am_set_do_not_verify_logout_signature(cmd_parms *cmd,
                                           void *struct_ptr,
                                           const char *key)
 {
-#ifdef HAVE_lasso_profile_set_signature_verify_hint
     return am_set_hash_string_slot(cmd, struct_ptr, key, NULL);
-#else
-    return apr_pstrcat(cmd->pool, cmd->cmd->name,
-                       " is not usable as modmellon was compiled against "
-                       "a version of the lasso library which miss the "
-                       "function lasso_profile_set_signature_verify_hint.",
-                       NULL);
-#endif
 }
 
 /* This function handles the MellonMergeEnvVars configuration directive,

--- a/auth_mellon_diagnostics.c
+++ b/auth_mellon_diagnostics.c
@@ -501,8 +501,6 @@ am_diag_log_dir_cfg(request_rec *r, int level, am_dir_cfg_rec *cfg,
                           "MellonSPPrivateKeyFile (sp_private_key_file):");
     am_diag_log_file_data(r, level+1, cfg->sp_cert_file,
                           "MellonSPCertFile (sp_cert_file):");
-    am_diag_log_file_data(r, level+1, cfg->idp_public_key_file,
-                          "MellonIdPPublicKeyFile (idp_public_key_file):");
     am_diag_log_file_data(r, level+1, cfg->idp_ca_file,
                           "MellonIdPCAFile (idp_ca_file):");
 

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -322,9 +322,8 @@ static LassoServer *am_get_lasso_server(request_rec *r)
         if (am_server_add_providers(cfg, r) == 0) {
 	    AM_LOG_RERROR(APLOG_MARK, APLOG_ERR, 0, r,
 			  "Error adding IdP to lasso server object. Please"
-			  " verify the following configuration directives:"
-			  " MellonIdPMetadataFile and"
-                          " MellonIdPPublicKeyFile.");
+			  " verify the following configuration directive:"
+			  " MellonIdPMetadataFile.");
 
 	    lasso_server_destroy(cfg->server);
 	    cfg->server = NULL;

--- a/configure.ac
+++ b/configure.ac
@@ -58,15 +58,6 @@ AC_SUBST(APXS2)
 # We need the lasso library for SAML2 communication.
 PKG_CHECK_MODULES(LASSO, lasso)
 saved_LIBS=$LIBS; LIBS="$LIBS $LASSO_LIBS";
-AC_CHECK_LIB(lasso, lasso_server_new_from_buffers,
-	     [AC_DEFINE([HAVE_lasso_server_new_from_buffers],[],
-             [lasso library exports lasso_server_new_from_buffers])])
-AC_CHECK_LIB(lasso, lasso_server_load_metadata,
-             [AC_DEFINE([HAVE_lasso_server_load_metadata],[],
-             [lasso library exports lasso_server_load_metadata])])
-AC_CHECK_LIB(lasso, lasso_profile_set_signature_verify_hint,
-             [AC_DEFINE([HAVE_lasso_profile_set_signature_verify_hint],[],
-             [lasso library exports lasso_profile_set_signature_verify_hint])])
 AC_CHECK_LIB(lasso, lasso_ecp_request_new,
              [AC_DEFINE([HAVE_ECP],[],
              [lasso library supports ECP profile])])

--- a/doc/user_guide/mellon_user_guide.adoc
+++ b/doc/user_guide/mellon_user_guide.adoc
@@ -3523,8 +3523,6 @@ Mellon Directory Configuration for URL: /saml-test/protected.html
       XotXjsiL1KtqNW1k/oVtLwNP0trqqh9npWV+R3pDTckxIHQhOvs5VqQZANViH6mp
       YK53b9Bhr0TpIOKetFY68kQ=
       -----END CERTIFICATE-----
-  MellonIdPPublicKeyFile (idp_public_key_file):
-    file_data: NULL
   MellonIdPCAFile (idp_ca_file):
     file_data: NULL
   MellonIdPMetadataFile (idp_metadata): 1 items
@@ -3922,8 +3920,6 @@ Mellon Directory Configuration for URL: /mellon/login
       XotXjsiL1KtqNW1k/oVtLwNP0trqqh9npWV+R3pDTckxIHQhOvs5VqQZANViH6mp
       YK53b9Bhr0TpIOKetFY68kQ=
       -----END CERTIFICATE-----
-  MellonIdPPublicKeyFile (idp_public_key_file):
-    file_data: NULL
   MellonIdPCAFile (idp_ca_file):
     file_data: NULL
   MellonIdPMetadataFile (idp_metadata): 1 items
@@ -4330,8 +4326,6 @@ Mellon Directory Configuration for URL: /mellon/postResponse
       XotXjsiL1KtqNW1k/oVtLwNP0trqqh9npWV+R3pDTckxIHQhOvs5VqQZANViH6mp
       YK53b9Bhr0TpIOKetFY68kQ=
       -----END CERTIFICATE-----
-  MellonIdPPublicKeyFile (idp_public_key_file):
-    file_data: NULL
   MellonIdPCAFile (idp_ca_file):
     file_data: NULL
   MellonIdPMetadataFile (idp_metadata): 1 items
@@ -4822,8 +4816,6 @@ Mellon Directory Configuration for URL: /saml-test/protected.html
       XotXjsiL1KtqNW1k/oVtLwNP0trqqh9npWV+R3pDTckxIHQhOvs5VqQZANViH6mp
       YK53b9Bhr0TpIOKetFY68kQ=
       -----END CERTIFICATE-----
-  MellonIdPPublicKeyFile (idp_public_key_file):
-    file_data: NULL
   MellonIdPCAFile (idp_ca_file):
     file_data: NULL
   MellonIdPMetadataFile (idp_metadata): 1 items
@@ -5107,8 +5099,6 @@ Mellon Directory Configuration for URL: /favicon.ico
       XotXjsiL1KtqNW1k/oVtLwNP0trqqh9npWV+R3pDTckxIHQhOvs5VqQZANViH6mp
       YK53b9Bhr0TpIOKetFY68kQ=
       -----END CERTIFICATE-----
-  MellonIdPPublicKeyFile (idp_public_key_file):
-    file_data: NULL
   MellonIdPCAFile (idp_ca_file):
     file_data: NULL
   MellonIdPMetadataFile (idp_metadata): 1 items


### PR DESCRIPTION
Remove code pertaining to Lasso < 2.4. Given that this was released 2014 it seems safe to drop this now.

Having many ifdefs makes the code less maintainable and also keeps code that is in practice untested around, because the developers never compile the code with ancient lasso versions. Confusing bugs arise because some configuration options only work with some of the code and not the other.
    
This removes all code not satisfying the presence of:
 - lasso_server_new_from_buffers,
 - lasso_server_load_metadata,
 - lasso_profile_set_signature_verify_hint

It also removes the configuration option MellonIdPPublicKeyFile which would only actually do something if Mellon was compiled with a pre-2.4 lasso, otherwise would just be ignored.