### PR TITLE
IdP Initiate SLO Validate SessionIndex

### DIFF
--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -390,7 +390,8 @@ typedef struct am_cache_entry_t {
 typedef enum { 
     AM_CACHE_SESSION, 
     AM_CACHE_NAMEID,
-    AM_CACHE_ASSERTIONID
+    AM_CACHE_ASSERTIONID,
+    AM_CACHE_SESSIONINDEX
 } am_cache_key_t;
 
 /* Type for configuring environment variable names */
@@ -472,6 +473,8 @@ am_cache_entry_t *am_cache_new(request_rec *r,
                                const char *key,
                                const char *cookie_token);
 void am_cache_unlock(request_rec *r, am_cache_entry_t *entry);
+bool am_cache_mutex_lock(request_rec *r);
+void am_cache_mutex_unlock(request_rec *r);
 
 void am_cache_update_expires(request_rec *r, am_cache_entry_t *t, apr_time_t expires);
 void am_cache_update_idle_timeout(request_rec *r, am_cache_entry_t *t, int session_idle_timeout);
@@ -482,6 +485,7 @@ int am_cache_env_append(am_cache_entry_t *session,
 const char *am_cache_env_fetch_first(am_cache_entry_t *t,
                                      const char *var);
 void am_cache_delete(request_rec *r, am_cache_entry_t *session);
+void am_cache_delete_sessions(request_rec *r, apr_array_header_t *sessions);
 
 int am_cache_set_lasso_state(am_cache_entry_t *session,
                              const char *lasso_identity,
@@ -489,17 +493,25 @@ int am_cache_set_lasso_state(am_cache_entry_t *session,
                              const char *lasso_saml_response);
 const char *am_cache_get_lasso_identity(am_cache_entry_t *session);
 const char *am_cache_get_lasso_session(am_cache_entry_t *session);
-
+am_cache_entry_t *am_cache_get_session(request_rec *r,
+                                       am_cache_key_t type,
+                                       const char *key);
+apr_array_header_t *am_cache_get_sessions(request_rec *r,
+                                       am_cache_key_t type,
+                                       const char *key);
 
 am_cache_entry_t *am_get_request_session(request_rec *r);
 am_cache_entry_t *am_get_request_session_by_nameid(request_rec *r, 
                                                    char *nameid);
 am_cache_entry_t *am_get_request_session_by_assertionid(request_rec *r,
                                                         char *assertionid);
+apr_array_header_t *am_get_request_sessions_by_sessionindex(request_rec *r, GList *sessionindex);
+apr_array_header_t *am_get_request_sessions_by_nameid(request_rec *r, char *nameid);
 am_cache_entry_t *am_new_request_session(request_rec *r);
 void am_release_request_session(request_rec *r, am_cache_entry_t *session);
 void am_delete_request_session(request_rec *r, am_cache_entry_t *session);
-
+void am_delete_request_sessions(request_rec *r, apr_array_header_t *sessions);
+bool am_validate_session_cookie_token(request_rec *r, am_cache_entry_t *session);
 
 char *am_reconstruct_url(request_rec *r);
 int am_validate_redirect_url(request_rec *r, const char *url);

--- a/auth_mellon_diagnostics.c
+++ b/auth_mellon_diagnostics.c
@@ -813,6 +813,7 @@ am_diag_cache_key_type_str(am_cache_key_t key_type)
     case AM_CACHE_SESSION:      return "session";
     case AM_CACHE_NAMEID:       return "name id";
     case AM_CACHE_ASSERTIONID:  return "assertion id";
+    case AM_CACHE_SESSIONINDEX:  return "SessionIndex";
     default:                    return "unknown";
     }
 }
@@ -1111,6 +1112,7 @@ am_diag_log_cache_entry(request_rec *r, int level, am_cache_entry_t *entry,
 
     const char *name_id = NULL;
     const char *assertion_id = NULL;
+    const char *sessionindex = NULL;
 
     if (!AM_DIAG_ENABLED(diag_cfg)) return;
     if (!am_diag_initialize_req(r, diag_cfg, req_cfg)) return;
@@ -1122,6 +1124,7 @@ am_diag_log_cache_entry(request_rec *r, int level, am_cache_entry_t *entry,
     if (entry) {
         name_id = am_cache_env_fetch_first(entry, "NAME_ID");
         assertion_id = am_cache_env_fetch_first(entry, "ASSERTION_ID");
+        sessionindex = am_cache_env_fetch_first(entry, "SESSIONINDEX");
 
         apr_file_printf(diag_cfg->fd,
                         "%skey: %s\n",
@@ -1132,6 +1135,9 @@ am_diag_log_cache_entry(request_rec *r, int level, am_cache_entry_t *entry,
         apr_file_printf(diag_cfg->fd,
                         "%sassertion_id: %s\n",
                         indent(level+1), assertion_id);
+        apr_file_printf(diag_cfg->fd,
+                        "%ssessionindex: %s\n",
+                        indent(level+1), sessionindex);
         apr_file_printf(diag_cfg->fd,
                         "%sexpires: %s\n",
                         indent(level+1),


### PR DESCRIPTION
Internal Server Error when IdP-Initiated Single Logout(#140)

Stores the SessionIndex in the cache, Validate SessionIndex on single logout.