### PR TITLE
accept hyphen in host names.

### DIFF
--- a/mellon_create_metadata.sh
+++ b/mellon_create_metadata.sh
@@ -36,7 +36,7 @@ fi
 HOST="$(echo "$BASEURL" | sed 's#^[a-z]*://\([^:/]*\).*#\1#')"
 BASEURL="$(echo "$BASEURL" | sed 's#/$##')"
 
-OUTFILE="$(echo "$ENTITYID" | sed 's/[^0-9A-Za-z.]/_/g' | sed 's/__*/_/g')"
+OUTFILE="$(echo "$ENTITYID" | sed 's/[^0-9A-Za-z.-]/_/g' | sed 's/__*/_/g')"
 echo "Output files:"
 echo "Private key:               $OUTFILE.key"
 echo "Certificate:               $OUTFILE.cert"


### PR DESCRIPTION
Please accept hyphen of the hosts in the OUTFILE's file name.
According to RFC953, the use of hyphens in host names is permitted.
